### PR TITLE
feat!: use Go 1.18 Generics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,14 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - name: Set up Go
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.13
-      id: go
+        go-version-file: go.mod
 
     - name: Check out
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build
       run: go build -v

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ import (
 )
 
 func main() {
-	load := func(k cache.Key) (cache.Value, error) {
+	load := func(k int) (string, error) {
 		time.Sleep(100 * time.Millisecond) // Slow task
 		return fmt.Sprintf("%d", k), nil
 	}
 	// Create a loading cache
 	c := cache.NewLoadingCache(load,
-		cache.WithMaximumSize(100),                 // Limit number of entries in the cache.
-		cache.WithExpireAfterAccess(1*time.Minute), // Expire entries after 1 minute since last accessed.
-		cache.WithRefreshAfterWrite(2*time.Minute), // Expire entries after 2 minutes since last created.
+		cache.WithMaximumSize[int, string](100),                 // Limit number of entries in the cache.
+		cache.WithExpireAfterAccess[int, string](1*time.Minute), // Expire entries after 1 minute since last accessed.
+		cache.WithRefreshAfterWrite[int, string](2*time.Minute), // Expire entries after 2 minutes since last created.
 	)
 
 	getTicker := time.Tick(100 * time.Millisecond)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -58,7 +58,7 @@ func BenchmarkHotspot(b *testing.B) {
 }
 
 func benchmarkCache(b *testing.B, g synthetic.Generator) {
-	c := New(WithMaximumSize(testMaxSize))
+	c := New(WithMaximumSize[int, int](testMaxSize))
 	defer c.Close()
 
 	intCh := make(chan int, 100)
@@ -86,7 +86,7 @@ func benchmarkCache(b *testing.B, g synthetic.Generator) {
 	})
 }
 
-func printStats(b *testing.B, c Cache, start time.Time) {
+func printStats(b *testing.B, c Cache[int, int], start time.Time) {
 	dur := time.Since(start)
 
 	var st Stats

--- a/cache.go
+++ b/cache.go
@@ -2,16 +2,9 @@
 // including support for LRU, Segmented LRU and TinyLFU.
 package cache
 
-// Key is any value which is comparable.
-// See http://golang.org/ref/spec#Comparison_operators for details.
-type Key interface{}
-
-// Value is any value.
-type Value interface{}
-
 // Cache is a key-value cache which entries are added and stayed in the
 // cache until either are evicted or manually invalidated.
-type Cache interface {
+type Cache[Key comparable, Value any] interface {
 	// GetIfPresent returns value associated with Key or (nil, false)
 	// if there is no cached value for Key.
 	GetIfPresent(Key) (Value, bool)
@@ -36,12 +29,12 @@ type Cache interface {
 }
 
 // Func is a generic callback for entry events in the cache.
-type Func func(Key, Value)
+type Func[Key comparable, Value any] func(Key, Value)
 
 // LoadingCache is a cache with values are loaded automatically and stored
 // in the cache until either evicted or manually invalidated.
-type LoadingCache interface {
-	Cache
+type LoadingCache[Key comparable, Value any] interface {
+	Cache[Key, Value]
 
 	// Get returns value associated with Key or call underlying LoaderFunc
 	// to load value if it is not present.
@@ -54,11 +47,11 @@ type LoadingCache interface {
 }
 
 // LoaderFunc retrieves the value corresponding to given Key.
-type LoaderFunc func(Key) (Value, error)
+type LoaderFunc[Key comparable, Value any] func(Key) (Value, error)
 
 // Reloader specifies how cache loader is run to refresh value for the given Key.
 // If Reloader is not set, cache values are refreshed in a new go routine.
-type Reloader interface {
+type Reloader[Key comparable, Value any] interface {
 	// Reload should reload the value asynchronously.
 	// Application must call setFunc to set new value or error.
 	Reload(key Key, oldValue Value, setFunc func(Value, error))

--- a/example/main.go
+++ b/example/main.go
@@ -9,19 +9,19 @@ import (
 )
 
 func main() {
-	load := func(k cache.Key) (cache.Value, error) {
+	load := func(k int) (string, error) {
 		fmt.Printf("loading %v\n", k)
 		time.Sleep(500 * time.Millisecond)
 		return fmt.Sprintf("%d-%d", k, time.Now().Unix()), nil
 	}
-	remove := func(k cache.Key, v cache.Value) {
+	remove := func(k int, v string) {
 		fmt.Printf("removed %v (%v)\n", k, v)
 	}
 	// Create a new cache
 	c := cache.NewLoadingCache(load,
-		cache.WithMaximumSize(1000),
-		cache.WithExpireAfterAccess(30*time.Second),
-		cache.WithRefreshAfterWrite(20*time.Second),
+		cache.WithMaximumSize[int, string](1000),
+		cache.WithExpireAfterAccess[int, string](30*time.Second),
+		cache.WithRefreshAfterWrite[int, string](20*time.Second),
 		cache.WithRemovalListener(remove),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/goburrow/cache
 
-go 1.13
+go 1.18

--- a/policy_test.go
+++ b/policy_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func BenchmarkCacheSegment(b *testing.B) {
-	c := cache{}
+	c := cache[int, int]{}
 	const count = 1 << 10
-	entries := make([]*entry, count)
+	entries := make([]*entry[int, int], count)
 	for i := range entries {
 		entries[i] = newEntry(i, i, uint64(i))
 	}

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 type tinyLFUTest struct {
-	c   cache
-	lfu tinyLFU
+	c   cache[int, string]
+	lfu tinyLFU[int, string]
 	t   *testing.T
 }
 
@@ -31,9 +31,9 @@ func (t *tinyLFUTest) assertLen(admission, protected, probation int) {
 	}
 }
 
-func (t *tinyLFUTest) assertEntry(en *entry, k int, v string, id uint8) {
-	ak := en.key.(int)
-	av := en.getValue().(string)
+func (t *tinyLFUTest) assertEntry(en *entry[int, string], k int, v string, id uint8) {
+	ak := en.key
+	av := en.getValue()
 	if ak != k || av != v || en.listID != id {
 		t.t.Helper()
 		t.t.Fatalf("unexpected entry: %+v, want: {key: %d, value: %s, listID: %d}",
@@ -47,8 +47,8 @@ func (t *tinyLFUTest) assertLRUEntry(k int, id uint8) {
 		t.t.Helper()
 		t.t.Fatalf("entry not found in cache: key=%v", k)
 	}
-	ak := en.key.(int)
-	av := en.getValue().(string)
+	ak := en.key
+	av := en.getValue()
 	v := fmt.Sprintf("%d", k)
 	if ak != k || av != v || en.listID != id {
 		t.t.Helper()
@@ -64,7 +64,7 @@ func TestTinyLFU(t *testing.T) {
 	s.lfu.slru.protectedCap = 2
 	s.lfu.slru.probationCap = 1
 
-	en := make([]*entry, 10)
+	en := make([]*entry[int, string], 10)
 	for i := range en {
 		en[i] = newEntry(i, fmt.Sprintf("%d", i), sum(i))
 	}

--- a/traces/.gitignore
+++ b/traces/.gitignore
@@ -1,0 +1,9 @@
+*-cachesize.png
+*-requests.png
+*.bz2
+*.dat
+*.gz
+*.tgz
+/traces/*.trace
+request_*.txt
+size_*.txt

--- a/traces/README.md
+++ b/traces/README.md
@@ -1,5 +1,17 @@
 # Cache performance report
 
+Requires [gnuplot](http://www.gnuplot.info/)
+
+Download the traces
+
+```
+./dl-address.sh
+./dl-cache2k.sh
+./dl-storage.sh
+./dl-wikipedia.sh
+./dl-youtube.sh
+```
+
 Run all tests
 ```
 ./report.sh
@@ -17,7 +29,7 @@ open out.png
 
 Name         | Source
 ------------ | ------
-Address      | [University of California, San Diego](http://cseweb.ucsd.edu/classes/fa07/cse240a/project1.html)
+Address      | [University of California, San Diego](https://cseweb.ucsd.edu/classes/fa07/cse240a/project1.html)
 CPP          | Authors of the LIRS algorithm - retrieved from [Cache2k](https://github.com/cache2k/cache2k-benchmark)
 Glimpse      | Authors of the LIRS algorithm - retrieved from [Cache2k](https://github.com/cache2k/cache2k-benchmark)
 Multi2       | Authors of the LIRS algorithm - retrieved from [Cache2k](https://github.com/cache2k/cache2k-benchmark)

--- a/traces/address.go
+++ b/traces/address.go
@@ -15,13 +15,13 @@ type addressProvider struct {
 // NewAddressProvider returns a Provider with items are from
 // application traces by the University of California, San Diego
 // (http://cseweb.ucsd.edu/classes/fa07/cse240a/project1.html).
-func NewAddressProvider(r io.Reader) Provider {
+func NewAddressProvider(r io.Reader) Provider[uint64] {
 	return &addressProvider{
 		r: bufio.NewReader(r),
 	}
 }
 
-func (p *addressProvider) Provide(ctx context.Context, keys chan<- interface{}) {
+func (p *addressProvider) Provide(ctx context.Context, keys chan<- uint64) {
 	defer close(keys)
 	for {
 		b, err := p.r.ReadBytes('\n')

--- a/traces/cache2k.go
+++ b/traces/cache2k.go
@@ -13,13 +13,13 @@ type cache2kProvider struct {
 
 // NewCache2kProvider returns a Provider which items are from traces
 // in Cache2k repository (https://github.com/cache2k/cache2k-benchmark).
-func NewCache2kProvider(r io.Reader) Provider {
+func NewCache2kProvider(r io.Reader) Provider[uint32] {
 	return &cache2kProvider{
 		r: bufio.NewReader(r),
 	}
 }
 
-func (p *cache2kProvider) Provide(ctx context.Context, keys chan<- interface{}) {
+func (p *cache2kProvider) Provide(ctx context.Context, keys chan<- uint32) {
 	defer close(keys)
 
 	v := make([]byte, 4)

--- a/traces/dl-address.sh
+++ b/traces/dl-address.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 FILE="proj1-traces.tar.gz"
-curl -O "http://cseweb.ucsd.edu/classes/fa07/cse240a/$FILE"
+curl -O "https://cseweb.ucsd.edu/classes/fa07/cse240a/$FILE"
 tar xvzf "$FILE"

--- a/traces/report.go
+++ b/traces/report.go
@@ -12,8 +12,8 @@ type Reporter interface {
 	Report(cache.Stats, options)
 }
 
-type Provider interface {
-	Provide(ctx context.Context, keys chan<- interface{})
+type Provider[Key comparable] interface {
+	Provide(ctx context.Context, keys chan<- Key)
 }
 
 type reporter struct {
@@ -48,11 +48,11 @@ var policies = []string{
 	"tinylfu",
 }
 
-func benchmarkCache(p Provider, r Reporter, opt options) {
-	c := cache.New(cache.WithMaximumSize(opt.cacheSize), cache.WithPolicy(opt.policy))
+func benchmarkCache[Key comparable](p Provider[Key], r Reporter, opt options) {
+	c := cache.New(cache.WithMaximumSize[Key, Key](opt.cacheSize), cache.WithPolicy[Key, Key](opt.policy))
 	defer c.Close()
 
-	keys := make(chan interface{}, 100)
+	keys := make(chan Key, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/traces/report.sh
+++ b/traces/report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 report() {

--- a/traces/report_test.go
+++ b/traces/report_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func testRequest(t *testing.T, newProvider func(io.Reader) Provider, opt options, traceFiles string, reportFile string) {
+func testRequest[Key comparable](t *testing.T, newProvider func(io.Reader) Provider[Key], opt options, traceFiles string, reportFile string) {
 	r, err := openFilesGlob(traceFiles)
 	if err != nil {
 		t.Skip(err)
@@ -23,7 +23,7 @@ func testRequest(t *testing.T, newProvider func(io.Reader) Provider, opt options
 	benchmarkCache(provider, reporter, opt)
 }
 
-func testSize(t *testing.T, newProvider func(io.Reader) Provider, opt options, traceFiles, reportFile string) {
+func testSize[Key comparable](t *testing.T, newProvider func(io.Reader) Provider[Key], opt options, traceFiles, reportFile string) {
 	r, err := openFilesGlob(traceFiles)
 	if err != nil {
 		t.Skip(err)

--- a/traces/storage.go
+++ b/traces/storage.go
@@ -15,13 +15,13 @@ type storageProvider struct {
 // NewStorageProvider returns a Provider with items are from
 // Storage traces by the University of Massachusetts
 // (http://traces.cs.umass.edu/index.php/Storage/Storage).
-func NewStorageProvider(r io.Reader) Provider {
+func NewStorageProvider(r io.Reader) Provider[uint64] {
 	return &storageProvider{
 		r: bufio.NewReader(r),
 	}
 }
 
-func (p *storageProvider) Provide(ctx context.Context, keys chan<- interface{}) {
+func (p *storageProvider) Provide(ctx context.Context, keys chan<- uint64) {
 	defer close(keys)
 	for {
 		b, err := p.r.ReadBytes('\n')

--- a/traces/visualize-request.sh
+++ b/traces/visualize-request.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z "$FORMAT" ]; then
 	#FORMAT='svg size 400,300 font "Helvetica,10"'
 	FORMAT='png size 220,180 small noenhanced'

--- a/traces/visualize-size.sh
+++ b/traces/visualize-size.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z "$FORMAT" ]; then
 	#FORMAT='svg size 400,300 font "Helvetica,10"'
 	FORMAT='png size 220,180 small noenhanced'

--- a/traces/wikipedia.go
+++ b/traces/wikipedia.go
@@ -11,13 +11,13 @@ type wikipediaProvider struct {
 	r *bufio.Reader
 }
 
-func NewWikipediaProvider(r io.Reader) Provider {
+func NewWikipediaProvider(r io.Reader) Provider[string] {
 	return &wikipediaProvider{
 		r: bufio.NewReader(r),
 	}
 }
 
-func (p *wikipediaProvider) Provide(ctx context.Context, keys chan<- interface{}) {
+func (p *wikipediaProvider) Provide(ctx context.Context, keys chan<- string) {
 	defer close(keys)
 	for {
 		b, err := p.r.ReadBytes('\n')

--- a/traces/youtube.go
+++ b/traces/youtube.go
@@ -11,13 +11,13 @@ type youtubeProvider struct {
 	r *bufio.Reader
 }
 
-func NewYoutubeProvider(r io.Reader) Provider {
+func NewYoutubeProvider(r io.Reader) Provider[string] {
 	return &youtubeProvider{
 		r: bufio.NewReader(r),
 	}
 }
 
-func (p *youtubeProvider) Provide(ctx context.Context, keys chan<- interface{}) {
+func (p *youtubeProvider) Provide(ctx context.Context, keys chan<- string) {
 	defer close(keys)
 	for {
 		b, err := p.r.ReadBytes('\n')

--- a/traces/zipf.go
+++ b/traces/zipf.go
@@ -10,7 +10,7 @@ type zipfProvider struct {
 	n int
 }
 
-func NewZipfProvider(s float64, num int) Provider {
+func NewZipfProvider(s float64, num int) Provider[uint64] {
 	if s <= 1.0 || num <= 0 {
 		panic("invalid zipf parameters")
 	}
@@ -21,7 +21,7 @@ func NewZipfProvider(s float64, num int) Provider {
 	}
 }
 
-func (p *zipfProvider) Provide(ctx context.Context, keys chan<- interface{}) {
+func (p *zipfProvider) Provide(ctx context.Context, keys chan<- uint64) {
 	defer close(keys)
 	for i := 0; i < p.n; i++ {
 		v := p.r.Uint64()


### PR DESCRIPTION
This adds type parameters and remove the use of `interface{}` and type assertions for improved type safety.
I have not observe any significant impact on performance (positive or negative).

It is obviously a breaking change.